### PR TITLE
fix(report) Duration must be an integer.

### DIFF
--- a/src/report.php
+++ b/src/report.php
@@ -436,7 +436,7 @@ class report extends asynchronous
         foreach ($score->getDurations() as $duration) {
             if ($testSuiteName === $duration['class'] &&
                 $testCaseName  === $duration['method']) {
-                return round($duration['value'] * 1000, 2);
+                return round($duration['value'] * 1000, 0);
             }
         }
 

--- a/test/unit/report.php
+++ b/test/unit/report.php
@@ -15,7 +15,7 @@ class report extends test
     const TEST_SUITE_NAME = 'C';
     const TEST_CASE_NAME  = 'f';
     const TEST_PATH       = '/dev/null';
-    const TEST_DURATION   = 0.42;
+    const TEST_DURATION   = 7;
 
     public function testTestRunStart()
     {


### PR DESCRIPTION
Quoting https://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity:

> duration (optional numeric attribute) - sets the test duration in
> milliseconds (should be an integer) to be reported in TeamCity UI. If
> omitted, the test duration will be calculated from the messages
> timestamps. If the timestamps are missing, from the actual time the
> messages were received on the server.